### PR TITLE
Add Scalar Search Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Scalar Search**: New `scalars_search` tool for finding scalars within a program.
+
 ## [2.0.0] - 2025-11-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - **Scalar Search**: New `scalars_search` tool for finding scalars within a program.
+  - Supports `in_function` filter to narrow results to scalars within specific containing functions (case-insensitive substring match on function name).
 
 ## [2.0.0] - 2025-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - **Scalar Search**: New `scalars_search` tool for finding scalars within a program.
   - Supports `in_function` filter to narrow results to scalars within specific containing functions (case-insensitive substring match on function name).
+  - Supports `to_function` filter to find scalars used as arguments in calls to specific functions (e.g., find all `0` values passed to `memset`).
 
 ## [2.0.0] - 2025-11-11
 

--- a/GHIDRA_HTTP_API.md
+++ b/GHIDRA_HTTP_API.md
@@ -599,6 +599,37 @@ Provides functionality for creating and managing struct (composite) data types.
   }
   ```
 
+### 6.3 Scalars
+
+Search for scalar (constant) values in instructions, similar to Ghidra's "Search For Scalar" feature.
+
+- **`GET /scalars`**: Search for occurrences of a specific scalar value in instructions.
+  - Query Parameters:
+    - `?value=[int]`: **Required.** The scalar value to search for (hex `0x...` or decimal).
+    - `?offset=[int]`: Pagination offset (default: 0).
+    - `?limit=[int]`: Maximum number of results to return (default: 100).
+  ```json
+  // Example Response for GET /scalars?value=0x1000
+  "result": [
+    {
+      "address": "0x00401234",
+      "value": 4096,
+      "hexValue": "0x1000",
+      "bitLength": 32,
+      "signed": false,
+      "operandIndex": 1,
+      "instruction": "MOV EAX, 0x1000",
+      "function": "main",
+      "functionAddress": "0x00401200"
+    }
+  ],
+  "_links": {
+    "self": { "href": "/scalars?value=0x1000&offset=0&limit=100" },
+    "next": { "href": "/scalars?value=0x1000&offset=100&limit=100" },
+    "program": { "href": "/program" }
+  }
+  ```
+
 ### 7. Memory Segments
 
 Represents memory blocks/sections defined in the program. 

--- a/GHIDRA_HTTP_API.md
+++ b/GHIDRA_HTTP_API.md
@@ -606,10 +606,11 @@ Search for scalar (constant) values in instructions, similar to Ghidra's "Search
 - **`GET /scalars`**: Search for occurrences of a specific scalar value in instructions.
   - Query Parameters:
     - `?value=[int]`: **Required.** The scalar value to search for (hex `0x...` or decimal).
+    - `?in_function=[string]`: Filter to only include results in functions whose name contains this substring (case-insensitive). This filters by the **containing** function where the scalar appears, not by called functions.
     - `?offset=[int]`: Pagination offset (default: 0).
     - `?limit=[int]`: Maximum number of results to return (default: 100).
   ```json
-  // Example Response for GET /scalars?value=0x1000
+  // Example Response for GET /scalars?value=0x1000&in_function=main
   "result": [
     {
       "address": "0x00401234",
@@ -624,8 +625,8 @@ Search for scalar (constant) values in instructions, similar to Ghidra's "Search
     }
   ],
   "_links": {
-    "self": { "href": "/scalars?value=0x1000&offset=0&limit=100" },
-    "next": { "href": "/scalars?value=0x1000&offset=100&limit=100" },
+    "self": { "href": "/scalars?value=0x1000&in_function=main&offset=0&limit=100" },
+    "next": { "href": "/scalars?value=0x1000&in_function=main&offset=100&limit=100" },
     "program": { "href": "/program" }
   }
   ```

--- a/GHIDRA_HTTP_API.md
+++ b/GHIDRA_HTTP_API.md
@@ -606,27 +606,30 @@ Search for scalar (constant) values in instructions, similar to Ghidra's "Search
 - **`GET /scalars`**: Search for occurrences of a specific scalar value in instructions.
   - Query Parameters:
     - `?value=[int]`: **Required.** The scalar value to search for (hex `0x...` or decimal).
-    - `?in_function=[string]`: Filter to only include results in functions whose name contains this substring (case-insensitive). This filters by the **containing** function where the scalar appears, not by called functions.
+    - `?in_function=[string]`: Filter to only include results in functions whose name contains this substring (case-insensitive). This filters by the **containing** function where the scalar appears.
+    - `?to_function=[string]`: Filter to only include results where the instruction is a call to a function whose name contains this substring (case-insensitive). Useful for finding specific arguments passed to a function.
     - `?offset=[int]`: Pagination offset (default: 0).
     - `?limit=[int]`: Maximum number of results to return (default: 100).
   ```json
-  // Example Response for GET /scalars?value=0x1000&in_function=main
+  // Example Response for GET /scalars?value=0&to_function=memset
   "result": [
     {
       "address": "0x00401234",
-      "value": 4096,
-      "hexValue": "0x1000",
+      "value": 0,
+      "hexValue": "0x0",
       "bitLength": 32,
       "signed": false,
       "operandIndex": 1,
-      "instruction": "MOV EAX, 0x1000",
-      "function": "main",
-      "functionAddress": "0x00401200"
+      "instruction": "PUSH 0x0",
+      "inFunction": "main",
+      "inFunctionAddress": "0x00401200",
+      "toFunction": "memset",
+      "toFunctionAddress": "0x00402000"
     }
   ],
   "_links": {
-    "self": { "href": "/scalars?value=0x1000&in_function=main&offset=0&limit=100" },
-    "next": { "href": "/scalars?value=0x1000&in_function=main&offset=100&limit=100" },
+    "self": { "href": "/scalars?value=0&to_function=memset&offset=0&limit=100" },
+    "next": { "href": "/scalars?value=0&to_function=memset&offset=100&limit=100" },
     "program": { "href": "/program" }
   }
   ```

--- a/bridge_mcp_hydra.py
+++ b/bridge_mcp_hydra.py
@@ -49,6 +49,7 @@ The API is organized into namespaces for different types of operations:
 - functions_* : For working with functions
 - data_* : For working with data items
 - structs_* : For creating and managing struct data types
+- scalars_* : For searching scalar (constant) values in instructions
 - memory_* : For memory access
 - xrefs_* : For cross-references
 - analysis_* : For program analysis
@@ -1946,6 +1947,31 @@ def data_set_type(address: str, data_type: str, port: int = None) -> dict:
     }
     
     response = safe_post(port, "data/type", payload)
+    return simplify_response(response)
+
+# Scalars tools
+@mcp.tool()
+def scalars_search(value: str, offset: int = 0, limit: int = 100, port: int = None) -> dict:
+    """Search for occurrences of a specific scalar (constant) value in instructions
+
+    Args:
+        value: The scalar value to search for (hex "0x..." or decimal)
+        offset: Pagination offset (default: 0)
+        limit: Maximum items to return (default: 100)
+        port: Specific Ghidra instance port (optional)
+
+    Returns:
+        dict: List of scalar occurrences with address, instruction, function context
+    """
+    port = _get_instance_port(port)
+
+    params = {
+        "value": value,
+        "offset": offset,
+        "limit": limit
+    }
+
+    response = safe_get(port, "scalars", params)
     return simplify_response(response)
 
 # Struct tools

--- a/bridge_mcp_hydra.py
+++ b/bridge_mcp_hydra.py
@@ -1951,11 +1951,12 @@ def data_set_type(address: str, data_type: str, port: int = None) -> dict:
 
 # Scalars tools
 @mcp.tool()
-def scalars_search(value: str, offset: int = 0, limit: int = 100, port: int = None) -> dict:
+def scalars_search(value: str, in_function: str = None, offset: int = 0, limit: int = 100, port: int = None) -> dict:
     """Search for occurrences of a specific scalar (constant) value in instructions
 
     Args:
         value: The scalar value to search for (hex "0x..." or decimal)
+        in_function: Filter to only include results in functions whose name contains this substring (case-insensitive)
         offset: Pagination offset (default: 0)
         limit: Maximum items to return (default: 100)
         port: Specific Ghidra instance port (optional)
@@ -1970,6 +1971,8 @@ def scalars_search(value: str, offset: int = 0, limit: int = 100, port: int = No
         "offset": offset,
         "limit": limit
     }
+    if in_function:
+        params["in_function"] = in_function
 
     response = safe_get(port, "scalars", params)
     return simplify_response(response)

--- a/bridge_mcp_hydra.py
+++ b/bridge_mcp_hydra.py
@@ -1951,12 +1951,16 @@ def data_set_type(address: str, data_type: str, port: int = None) -> dict:
 
 # Scalars tools
 @mcp.tool()
-def scalars_search(value: str, in_function: str = None, offset: int = 0, limit: int = 100, port: int = None) -> dict:
+def scalars_search(value: str, in_function: str = None, to_function: str = None, offset: int = 0, limit: int = 100, port: int = None) -> dict:
     """Search for occurrences of a specific scalar (constant) value in instructions
+
+    Use to find where a constant appears in code. For named constants, look up
+    the value with data_list first.
 
     Args:
         value: The scalar value to search for (hex "0x..." or decimal)
-        in_function: Filter to only include results in functions whose name contains this substring (case-insensitive)
+        in_function: Filter by containing function name (case-insensitive substring)
+        to_function: Filter by called function name (case-insensitive substring)
         offset: Pagination offset (default: 0)
         limit: Maximum items to return (default: 100)
         port: Specific Ghidra instance port (optional)
@@ -1973,6 +1977,8 @@ def scalars_search(value: str, in_function: str = None, offset: int = 0, limit: 
     }
     if in_function:
         params["in_function"] = in_function
+    if to_function:
+        params["to_function"] = to_function
 
     response = safe_get(port, "scalars", params)
     return simplify_response(response)

--- a/src/main/java/eu/starsong/ghidra/GhydraMCPPlugin.java
+++ b/src/main/java/eu/starsong/ghidra/GhydraMCPPlugin.java
@@ -144,6 +144,7 @@ public class GhydraMCPPlugin extends Plugin implements ApplicationLevelPlugin {
         new XrefsEndpoints(currentProgram, port, tool).registerEndpoints(server);
         new AnalysisEndpoints(currentProgram, port, tool).registerEndpoints(server);
         new ProgramEndpoints(currentProgram, port, tool).registerEndpoints(server);
+        new ScalarEndpoints(currentProgram, port, tool).registerEndpoints(server);
         
         Msg.info(this, "Registered program-dependent endpoints. Programs will be checked at runtime.");
     }

--- a/src/main/java/eu/starsong/ghidra/endpoints/ScalarEndpoints.java
+++ b/src/main/java/eu/starsong/ghidra/endpoints/ScalarEndpoints.java
@@ -1,0 +1,243 @@
+package eu.starsong.ghidra.endpoints;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import ghidra.framework.plugintool.PluginTool;
+import ghidra.program.model.address.Address;
+import ghidra.program.model.listing.Instruction;
+import ghidra.program.model.listing.InstructionIterator;
+import ghidra.program.model.listing.Listing;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryBlock;
+import ghidra.program.model.scalar.Scalar;
+import ghidra.util.Msg;
+
+import eu.starsong.ghidra.model.ScalarInfo;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * Endpoints for searching scalar (constant) values in the binary.
+ * Similar to Ghidra's "Search For Scalar" functionality.
+ */
+public class ScalarEndpoints extends AbstractEndpoint {
+
+    private PluginTool tool;
+
+    public ScalarEndpoints(Program program, int port) {
+        super(program, port);
+    }
+
+    public ScalarEndpoints(Program program, int port, PluginTool tool) {
+        super(program, port);
+        this.tool = tool;
+    }
+
+    @Override
+    protected PluginTool getTool() {
+        return tool;
+    }
+
+    @Override
+    public void registerEndpoints(HttpServer server) {
+        server.createContext("/scalars", this::handleScalars);
+    }
+
+    /**
+     * Handle GET /scalars?value=X - Search for occurrences of a specific scalar
+     * value
+     *
+     * Query parameters:
+     * - value: The scalar value to search for (required, hex 0x... or decimal)
+     * - offset: Pagination offset (default: 0)
+     * - limit: Maximum items to return (default: 100)
+     */
+    public void handleScalars(HttpExchange exchange) throws IOException {
+        try {
+            if ("GET".equals(exchange.getRequestMethod())) {
+                Map<String, String> qparams = parseQueryParams(exchange);
+                int offset = parseIntOrDefault(qparams.get("offset"), 0);
+                int limit = parseIntOrDefault(qparams.get("limit"), 100);
+
+                // Value is required
+                String valueParam = qparams.get("value");
+                if (valueParam == null || valueParam.isEmpty()) {
+                    sendErrorResponse(exchange, 400, "Missing required parameter: value", "MISSING_PARAMETER");
+                    return;
+                }
+
+                Long targetValue = parseScalarValue(valueParam);
+                if (targetValue == null) {
+                    sendErrorResponse(exchange, 400, "Invalid value format: " + valueParam, "INVALID_PARAMETER");
+                    return;
+                }
+
+                Program program = getCurrentProgram();
+                if (program == null) {
+                    sendErrorResponse(exchange, 400, "No program loaded", "NO_PROGRAM_LOADED");
+                    return;
+                }
+
+                // Find scalars with early termination (skip offset, collect limit + 1 to check
+                // hasMore)
+                FindScalarResult findResult = findScalar(program, targetValue, offset, limit);
+
+                // Build response with HATEOAS links
+                eu.starsong.ghidra.api.ResponseBuilder builder = new eu.starsong.ghidra.api.ResponseBuilder(exchange,
+                        port)
+                        .success(true);
+
+                // Set the result
+                builder.result(findResult.results);
+
+                // Add pagination metadata
+                Map<String, Object> metadata = new HashMap<>();
+                metadata.put("offset", offset);
+                metadata.put("limit", limit);
+                metadata.put("returned", findResult.results.size());
+                builder.metadata(metadata);
+
+                // Add pagination links
+                String baseParams = "value=" + valueParam;
+                builder.addLink("self", "/scalars?" + baseParams + "&offset=" + offset + "&limit=" + limit);
+
+                if (findResult.hasMore) {
+                    builder.addLink("next",
+                            "/scalars?" + baseParams + "&offset=" + (offset + limit) + "&limit=" + limit);
+                }
+
+                if (offset > 0) {
+                    int prevOffset = Math.max(0, offset - limit);
+                    builder.addLink("prev", "/scalars?" + baseParams + "&offset=" + prevOffset + "&limit=" + limit);
+                }
+
+                // Add useful links
+                builder.addLink("program", "/program");
+
+                sendJsonResponse(exchange, builder.build(), 200);
+            } else {
+                sendErrorResponse(exchange, 405, "Method Not Allowed", "METHOD_NOT_ALLOWED");
+            }
+        } catch (Exception e) {
+            Msg.error(this, "Error in /scalars endpoint", e);
+            sendErrorResponse(exchange, 500, "Internal server error: " + e.getMessage(), "INTERNAL_ERROR");
+        }
+    }
+
+    /**
+     * Result container for findScalar with pagination info
+     */
+    private static class FindScalarResult {
+        List<ScalarInfo> results;
+        boolean hasMore;
+
+        FindScalarResult(List<ScalarInfo> results, boolean hasMore) {
+            this.results = results;
+            this.hasMore = hasMore;
+        }
+    }
+
+    /**
+     * Find occurrences of a scalar value with offset/limit for pagination.
+     * Uses early termination for performance.
+     *
+     * @param program     The program to search
+     * @param targetValue The scalar value to find
+     * @param offset      Number of results to skip
+     * @param limit       Maximum results to return
+     * @return FindScalarResult containing results and hasMore flag
+     */
+    private FindScalarResult findScalar(Program program, long targetValue, int offset, int limit) {
+        List<ScalarInfo> results = new ArrayList<>();
+        Listing listing = program.getListing();
+        int skipped = 0;
+        int collected = 0;
+        boolean hasMore = false;
+
+        // Iterate through all memory blocks
+        outerLoop: for (MemoryBlock block : program.getMemory().getBlocks()) {
+            if (!block.isInitialized())
+                continue;
+
+            // Iterate through all instructions in the block
+            InstructionIterator instructions = listing.getInstructions(block.getStart(), true);
+            while (instructions.hasNext()) {
+                Instruction instruction = instructions.next();
+                Address instrAddr = instruction.getAddress();
+
+                // Stop if we're past the current block
+                if (!block.contains(instrAddr))
+                    break;
+
+                // Check all operands for the target scalar
+                int numOperands = instruction.getNumOperands();
+                for (int opIndex = 0; opIndex < numOperands; opIndex++) {
+                    Object[] opObjects = instruction.getOpObjects(opIndex);
+                    for (Object opObj : opObjects) {
+                        if (opObj instanceof Scalar) {
+                            Scalar scalar = (Scalar) opObj;
+                            if (scalar.getValue() == targetValue) {
+                                // Skip until we reach offset
+                                if (skipped < offset) {
+                                    skipped++;
+                                    continue;
+                                }
+
+                                // Check if we've collected enough (collect one extra to detect hasMore)
+                                if (collected >= limit) {
+                                    hasMore = true;
+                                    break outerLoop;
+                                }
+
+                                // Build the result using ScalarInfo model
+                                ScalarInfo.Builder builder = ScalarInfo.builder()
+                                    .address(instrAddr.toString())
+                                    .value(targetValue)
+                                    .bitLength(scalar.bitLength())
+                                    .signed(scalar.isSigned())
+                                    .operandIndex(opIndex)
+                                    .instruction(instruction.toString());
+
+                                // Add function context if available
+                                ghidra.program.model.listing.Function func = listing.getFunctionContaining(instrAddr);
+                                if (func != null) {
+                                    builder.function(func.getName(true))
+                                           .functionAddress(func.getEntryPoint().toString());
+                                }
+
+                                results.add(builder.build());
+                                collected++;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return new FindScalarResult(results, hasMore);
+    }
+
+    /**
+     * Parse a scalar value string that can be hex (0x...) or decimal
+     */
+    private Long parseScalarValue(String valueStr) {
+        if (valueStr == null || valueStr.isEmpty()) {
+            return null;
+        }
+
+        try {
+            valueStr = valueStr.trim();
+            if (valueStr.toLowerCase().startsWith("0x")) {
+                return Long.parseLong(valueStr.substring(2), 16);
+            } else if (valueStr.toLowerCase().startsWith("-0x")) {
+                return -Long.parseLong(valueStr.substring(3), 16);
+            } else {
+                return Long.parseLong(valueStr);
+            }
+        } catch (NumberFormatException e) {
+            Msg.warn(this, "Failed to parse scalar value: " + valueStr);
+            return null;
+        }
+    }
+}

--- a/src/main/java/eu/starsong/ghidra/model/ScalarInfo.java
+++ b/src/main/java/eu/starsong/ghidra/model/ScalarInfo.java
@@ -12,8 +12,10 @@ public class ScalarInfo {
     private boolean signed;
     private int operandIndex;
     private String instruction;
-    private String function;
-    private String functionAddress;
+    private String inFunction;
+    private String inFunctionAddress;
+    private String toFunction;
+    private String toFunctionAddress;
 
     /**
      * Default constructor for serialization frameworks
@@ -26,7 +28,8 @@ public class ScalarInfo {
      */
     public ScalarInfo(String address, long value, String hexValue, int bitLength,
                       boolean signed, int operandIndex, String instruction,
-                      String function, String functionAddress) {
+                      String inFunction, String inFunctionAddress,
+                      String toFunction, String toFunctionAddress) {
         this.address = address;
         this.value = value;
         this.hexValue = hexValue;
@@ -34,8 +37,10 @@ public class ScalarInfo {
         this.signed = signed;
         this.operandIndex = operandIndex;
         this.instruction = instruction;
-        this.function = function;
-        this.functionAddress = functionAddress;
+        this.inFunction = inFunction;
+        this.inFunctionAddress = inFunctionAddress;
+        this.toFunction = toFunction;
+        this.toFunctionAddress = toFunctionAddress;
     }
 
     public String getAddress() {
@@ -94,20 +99,36 @@ public class ScalarInfo {
         this.instruction = instruction;
     }
 
-    public String getFunction() {
-        return function;
+    public String getInFunction() {
+        return inFunction;
     }
 
-    public void setFunction(String function) {
-        this.function = function;
+    public void setInFunction(String inFunction) {
+        this.inFunction = inFunction;
     }
 
-    public String getFunctionAddress() {
-        return functionAddress;
+    public String getInFunctionAddress() {
+        return inFunctionAddress;
     }
 
-    public void setFunctionAddress(String functionAddress) {
-        this.functionAddress = functionAddress;
+    public void setInFunctionAddress(String inFunctionAddress) {
+        this.inFunctionAddress = inFunctionAddress;
+    }
+
+    public String getToFunction() {
+        return toFunction;
+    }
+
+    public void setToFunction(String toFunction) {
+        this.toFunction = toFunction;
+    }
+
+    public String getToFunctionAddress() {
+        return toFunctionAddress;
+    }
+
+    public void setToFunctionAddress(String toFunctionAddress) {
+        this.toFunctionAddress = toFunctionAddress;
     }
 
     /**
@@ -121,8 +142,10 @@ public class ScalarInfo {
         private boolean signed;
         private int operandIndex;
         private String instruction;
-        private String function;
-        private String functionAddress;
+        private String inFunction;
+        private String inFunctionAddress;
+        private String toFunction;
+        private String toFunctionAddress;
 
         public Builder address(String address) {
             this.address = address;
@@ -155,13 +178,23 @@ public class ScalarInfo {
             return this;
         }
 
-        public Builder function(String function) {
-            this.function = function;
+        public Builder inFunction(String inFunction) {
+            this.inFunction = inFunction;
             return this;
         }
 
-        public Builder functionAddress(String functionAddress) {
-            this.functionAddress = functionAddress;
+        public Builder inFunctionAddress(String inFunctionAddress) {
+            this.inFunctionAddress = inFunctionAddress;
+            return this;
+        }
+
+        public Builder toFunction(String toFunction) {
+            this.toFunction = toFunction;
+            return this;
+        }
+
+        public Builder toFunctionAddress(String toFunctionAddress) {
+            this.toFunctionAddress = toFunctionAddress;
             return this;
         }
 
@@ -169,7 +202,8 @@ public class ScalarInfo {
             return new ScalarInfo(
                 address, value, hexValue, bitLength,
                 signed, operandIndex, instruction,
-                function, functionAddress
+                inFunction, inFunctionAddress,
+                toFunction, toFunctionAddress
             );
         }
     }

--- a/src/main/java/eu/starsong/ghidra/model/ScalarInfo.java
+++ b/src/main/java/eu/starsong/ghidra/model/ScalarInfo.java
@@ -1,0 +1,180 @@
+package eu.starsong.ghidra.model;
+
+/**
+ * Model class representing a scalar (constant) value occurrence in the binary.
+ * This provides a structured object for scalar search results.
+ */
+public class ScalarInfo {
+    private String address;
+    private long value;
+    private String hexValue;
+    private int bitLength;
+    private boolean signed;
+    private int operandIndex;
+    private String instruction;
+    private String function;
+    private String functionAddress;
+
+    /**
+     * Default constructor for serialization frameworks
+     */
+    public ScalarInfo() {
+    }
+
+    /**
+     * Full constructor
+     */
+    public ScalarInfo(String address, long value, String hexValue, int bitLength,
+                      boolean signed, int operandIndex, String instruction,
+                      String function, String functionAddress) {
+        this.address = address;
+        this.value = value;
+        this.hexValue = hexValue;
+        this.bitLength = bitLength;
+        this.signed = signed;
+        this.operandIndex = operandIndex;
+        this.instruction = instruction;
+        this.function = function;
+        this.functionAddress = functionAddress;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public long getValue() {
+        return value;
+    }
+
+    public void setValue(long value) {
+        this.value = value;
+    }
+
+    public String getHexValue() {
+        return hexValue;
+    }
+
+    public void setHexValue(String hexValue) {
+        this.hexValue = hexValue;
+    }
+
+    public int getBitLength() {
+        return bitLength;
+    }
+
+    public void setBitLength(int bitLength) {
+        this.bitLength = bitLength;
+    }
+
+    public boolean isSigned() {
+        return signed;
+    }
+
+    public void setSigned(boolean signed) {
+        this.signed = signed;
+    }
+
+    public int getOperandIndex() {
+        return operandIndex;
+    }
+
+    public void setOperandIndex(int operandIndex) {
+        this.operandIndex = operandIndex;
+    }
+
+    public String getInstruction() {
+        return instruction;
+    }
+
+    public void setInstruction(String instruction) {
+        this.instruction = instruction;
+    }
+
+    public String getFunction() {
+        return function;
+    }
+
+    public void setFunction(String function) {
+        this.function = function;
+    }
+
+    public String getFunctionAddress() {
+        return functionAddress;
+    }
+
+    public void setFunctionAddress(String functionAddress) {
+        this.functionAddress = functionAddress;
+    }
+
+    /**
+     * Builder pattern for ScalarInfo
+     */
+    public static class Builder {
+        private String address;
+        private long value;
+        private String hexValue;
+        private int bitLength;
+        private boolean signed;
+        private int operandIndex;
+        private String instruction;
+        private String function;
+        private String functionAddress;
+
+        public Builder address(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public Builder value(long value) {
+            this.value = value;
+            this.hexValue = String.format("0x%x", value);
+            return this;
+        }
+
+        public Builder bitLength(int bitLength) {
+            this.bitLength = bitLength;
+            return this;
+        }
+
+        public Builder signed(boolean signed) {
+            this.signed = signed;
+            return this;
+        }
+
+        public Builder operandIndex(int operandIndex) {
+            this.operandIndex = operandIndex;
+            return this;
+        }
+
+        public Builder instruction(String instruction) {
+            this.instruction = instruction;
+            return this;
+        }
+
+        public Builder function(String function) {
+            this.function = function;
+            return this;
+        }
+
+        public Builder functionAddress(String functionAddress) {
+            this.functionAddress = functionAddress;
+            return this;
+        }
+
+        public ScalarInfo build() {
+            return new ScalarInfo(
+                address, value, hexValue, bitLength,
+                signed, operandIndex, instruction,
+                function, functionAddress
+            );
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+}


### PR DESCRIPTION
One of the neat things about Ghidra is the ability to search for scalar values. In my project, I have found it to be an incredibly useful tool for finding specific call sites of a function that takes a number of different enum values. In order to make this process easier, I have added support to the MCP server for performing scalar searches.

This allows for:

- `in_function` filter to narrow results to scalars within specific containing functions (case-insensitive substring match on function name).
- `to_function` filter to find scalars used as arguments in calls to specific functions (e.g., find all `0` values passed to `memset`).

### Testing Instructions

In my case, I am using Claude Code.

- Ask it to find a specific scalar value.
- Ask it to find instances of a specific function being passed as specific scalar value.