### PR TITLE
Add Missing Data Name Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Missing Data Name Filters**: Although name and name_contains were documented for data endpoints, they weren't actually implemented until now.
+
 ## [2.0.0] - 2025-11-11
 
 ### Added

--- a/src/main/java/eu/starsong/ghidra/endpoints/DataEndpoints.java
+++ b/src/main/java/eu/starsong/ghidra/endpoints/DataEndpoints.java
@@ -182,6 +182,12 @@ package eu.starsong.ghidra.endpoints;
                     return;
                 }
                 
+                // Get filter parameters
+                String addrFilter = qparams.get("addr");
+                String nameFilter = qparams.get("name");
+                String nameContainsFilter = qparams.get("name_contains");
+                String typeFilter = qparams.get("type");
+
                 List<Map<String, Object>> dataItems = new ArrayList<>();
                 for (MemoryBlock block : program.getMemory().getBlocks()) {
                     DataIterator it = program.getListing().getDefinedData(block.getStart(), true);
@@ -189,14 +195,41 @@ package eu.starsong.ghidra.endpoints;
                         Data data = it.next();
                         if (block.contains(data.getAddress())) {
                             // Apply addr filter if present
-                            String addrFilter = qparams.get("addr");
                             if (addrFilter != null && !data.getAddress().toString().equals(addrFilter)) {
-                                continue; // Skip this data item if address doesn't match filter
+                                continue;
+                            }
+
+                            // Get the name/label for this data item (use FQN for consistency)
+                            String dataName = data.getLabel();
+                            if (dataName == null) {
+                                Symbol sym = program.getSymbolTable().getPrimarySymbol(data.getAddress());
+                                if (sym != null) {
+                                    dataName = sym.getName(true);
+                                }
+                            }
+
+                            // Apply name filter (exact match, case-sensitive)
+                            if (nameFilter != null) {
+                                if (dataName == null || !dataName.equals(nameFilter)) {
+                                    continue;
+                                }
+                            }
+
+                            // Apply name_contains filter (substring, case-insensitive)
+                            if (nameContainsFilter != null) {
+                                if (dataName == null || !dataName.toLowerCase().contains(nameContainsFilter.toLowerCase())) {
+                                    continue;
+                                }
+                            }
+
+                            // Apply type filter
+                            if (typeFilter != null && !data.getDataType().getName().equalsIgnoreCase(typeFilter)) {
+                                continue;
                             }
 
                             Map<String, Object> item = new HashMap<>();
                             item.put("address", data.getAddress().toString());
-                            item.put("label", data.getLabel() != null ? data.getLabel() : "(unnamed)");
+                            item.put("label", dataName != null ? dataName : "(unnamed)");
                             item.put("value", data.getDefaultValueRepresentation());
                             item.put("dataType", data.getDataType().getName());
                             


### PR DESCRIPTION
Both `name` and `name_contains` fields are documented as options for `data_*` endpoints. They were not. Now they are!

**Note**: This pull request uses the fully-qualified names based on the changes made in #18.